### PR TITLE
Dynamic json unmarshal

### DIFF
--- a/cty/json/unmarshal.go
+++ b/cty/json/unmarshal.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/go-cty/cty/convert"
 )
 
-func unmarshal(buf []byte, t cty.Type, path cty.Path) (cty.Value, error) {
+func unmarshal(buf []byte, t cty.Type, path cty.Path, opt *UnmarshalOptions) (cty.Value, error) {
 	dec := bufDecoder(buf)
 
 	tok, err := dec.Token()
@@ -22,35 +22,37 @@ func unmarshal(buf []byte, t cty.Type, path cty.Path) (cty.Value, error) {
 		return cty.NullVal(t), nil
 	}
 
-	if t == cty.DynamicPseudoType {
-		return unmarshalDynamic(buf, path)
-	}
-
 	switch {
 	case t.IsPrimitiveType():
-		val, err := unmarshalPrimitive(tok, t, path)
+		val, err := unmarshalPrimitive(tok, t, path, opt)
 		if err != nil {
 			return cty.NilVal, err
 		}
 		return val, nil
 	case t.IsListType():
-		return unmarshalList(buf, t.ElementType(), path)
+		return unmarshalList(buf, t.ElementType(), path, opt)
 	case t.IsSetType():
-		return unmarshalSet(buf, t.ElementType(), path)
+		return unmarshalSet(buf, t.ElementType(), path, opt)
 	case t.IsMapType():
-		return unmarshalMap(buf, t.ElementType(), path)
+		return unmarshalMap(buf, t.ElementType(), path, opt)
 	case t.IsTupleType():
-		return unmarshalTuple(buf, t.TupleElementTypes(), path)
+		return unmarshalTuple(buf, t.TupleElementTypes(), path, opt)
 	case t.IsObjectType():
-		return unmarshalObject(buf, t.AttributeTypes(), path)
+		return unmarshalObject(buf, t.AttributeTypes(), path, opt)
 	case t.IsCapsuleType():
-		return unmarshalCapsule(buf, t, path)
+		return unmarshalCapsule(buf, t, path, opt)
+	case t.Equals(cty.DynamicPseudoType):
+		if opt.ImpliedDynamic {
+			return unmarshalIntoDynamic(buf, path, opt)
+		} else {
+			return unmarshalDynamic(buf, path, opt)
+		}
 	default:
 		return cty.NilVal, path.NewErrorf("unsupported type %s", t.FriendlyName())
 	}
 }
 
-func unmarshalPrimitive(tok json.Token, t cty.Type, path cty.Path) (cty.Value, error) {
+func unmarshalPrimitive(tok json.Token, t cty.Type, path cty.Path, opt *UnmarshalOptions) (cty.Value, error) {
 
 	switch t {
 	case cty.Bool:
@@ -101,7 +103,7 @@ func unmarshalPrimitive(tok json.Token, t cty.Type, path cty.Path) (cty.Value, e
 	}
 }
 
-func unmarshalList(buf []byte, ety cty.Type, path cty.Path) (cty.Value, error) {
+func unmarshalList(buf []byte, ety cty.Type, path cty.Path, opt *UnmarshalOptions) (cty.Value, error) {
 	dec := bufDecoder(buf)
 	if err := requireDelim(dec, '['); err != nil {
 		return cty.NilVal, path.NewError(err)
@@ -124,7 +126,7 @@ func unmarshalList(buf []byte, ety cty.Type, path cty.Path) (cty.Value, error) {
 				return cty.NilVal, path.NewErrorf("failed to read list value: %s", err)
 			}
 
-			el, err := unmarshal(rawVal, ety, path)
+			el, err := unmarshal(rawVal, ety, path, opt)
 			if err != nil {
 				return cty.NilVal, err
 			}
@@ -144,7 +146,7 @@ func unmarshalList(buf []byte, ety cty.Type, path cty.Path) (cty.Value, error) {
 	return cty.ListVal(vals), nil
 }
 
-func unmarshalSet(buf []byte, ety cty.Type, path cty.Path) (cty.Value, error) {
+func unmarshalSet(buf []byte, ety cty.Type, path cty.Path, opt *UnmarshalOptions) (cty.Value, error) {
 	dec := bufDecoder(buf)
 	if err := requireDelim(dec, '['); err != nil {
 		return cty.NilVal, path.NewError(err)
@@ -165,7 +167,7 @@ func unmarshalSet(buf []byte, ety cty.Type, path cty.Path) (cty.Value, error) {
 				return cty.NilVal, path.NewErrorf("failed to read set value: %s", err)
 			}
 
-			el, err := unmarshal(rawVal, ety, path)
+			el, err := unmarshal(rawVal, ety, path, opt)
 			if err != nil {
 				return cty.NilVal, err
 			}
@@ -185,7 +187,7 @@ func unmarshalSet(buf []byte, ety cty.Type, path cty.Path) (cty.Value, error) {
 	return cty.SetVal(vals), nil
 }
 
-func unmarshalMap(buf []byte, ety cty.Type, path cty.Path) (cty.Value, error) {
+func unmarshalMap(buf []byte, ety cty.Type, path cty.Path, opt *UnmarshalOptions) (cty.Value, error) {
 	dec := bufDecoder(buf)
 	if err := requireDelim(dec, '{'); err != nil {
 		return cty.NilVal, path.NewError(err)
@@ -217,7 +219,7 @@ func unmarshalMap(buf []byte, ety cty.Type, path cty.Path) (cty.Value, error) {
 				return cty.NilVal, path.NewErrorf("failed to read map value: %s", err)
 			}
 
-			el, err := unmarshal(rawVal, ety, path)
+			el, err := unmarshal(rawVal, ety, path, opt)
 			if err != nil {
 				return cty.NilVal, err
 			}
@@ -237,7 +239,7 @@ func unmarshalMap(buf []byte, ety cty.Type, path cty.Path) (cty.Value, error) {
 	return cty.MapVal(vals), nil
 }
 
-func unmarshalTuple(buf []byte, etys []cty.Type, path cty.Path) (cty.Value, error) {
+func unmarshalTuple(buf []byte, etys []cty.Type, path cty.Path, opt *UnmarshalOptions) (cty.Value, error) {
 	dec := bufDecoder(buf)
 	if err := requireDelim(dec, '['); err != nil {
 		return cty.NilVal, path.NewError(err)
@@ -265,7 +267,7 @@ func unmarshalTuple(buf []byte, etys []cty.Type, path cty.Path) (cty.Value, erro
 				return cty.NilVal, path.NewErrorf("failed to read tuple value: %s", err)
 			}
 
-			el, err := unmarshal(rawVal, ety, path)
+			el, err := unmarshal(rawVal, ety, path, opt)
 			if err != nil {
 				return cty.NilVal, err
 			}
@@ -289,7 +291,7 @@ func unmarshalTuple(buf []byte, etys []cty.Type, path cty.Path) (cty.Value, erro
 	return cty.TupleVal(vals), nil
 }
 
-func unmarshalObject(buf []byte, atys map[string]cty.Type, path cty.Path) (cty.Value, error) {
+func unmarshalObject(buf []byte, atys map[string]cty.Type, path cty.Path, opt *UnmarshalOptions) (cty.Value, error) {
 	dec := bufDecoder(buf)
 	if err := requireDelim(dec, '{'); err != nil {
 		return cty.NilVal, path.NewError(err)
@@ -324,7 +326,7 @@ func unmarshalObject(buf []byte, atys map[string]cty.Type, path cty.Path) (cty.V
 				return cty.NilVal, path.NewErrorf("failed to read object value: %s", err)
 			}
 
-			el, err := unmarshal(rawVal, aty, path)
+			el, err := unmarshal(rawVal, aty, path, opt)
 			if err != nil {
 				return cty.NilVal, err
 			}
@@ -351,7 +353,7 @@ func unmarshalObject(buf []byte, atys map[string]cty.Type, path cty.Path) (cty.V
 	return cty.ObjectVal(vals), nil
 }
 
-func unmarshalCapsule(buf []byte, t cty.Type, path cty.Path) (cty.Value, error) {
+func unmarshalCapsule(buf []byte, t cty.Type, path cty.Path, opt *UnmarshalOptions) (cty.Value, error) {
 	rawType := t.EncapsulatedType()
 	ptrPtr := reflect.New(reflect.PtrTo(rawType))
 	ptrPtr.Elem().Set(reflect.New(rawType))
@@ -364,7 +366,7 @@ func unmarshalCapsule(buf []byte, t cty.Type, path cty.Path) (cty.Value, error) 
 	return cty.CapsuleVal(t, ptr), nil
 }
 
-func unmarshalDynamic(buf []byte, path cty.Path) (cty.Value, error) {
+func unmarshalDynamic(buf []byte, path cty.Path, opt *UnmarshalOptions) (cty.Value, error) {
 	dec := bufDecoder(buf)
 	if err := requireDelim(dec, '{'); err != nil {
 		return cty.NilVal, path.NewError(err)
@@ -411,7 +413,7 @@ func unmarshalDynamic(buf []byte, path cty.Path) (cty.Value, error) {
 		return cty.NilVal, path.NewErrorf("missing value in dynamically-typed value")
 	}
 
-	val, err := Unmarshal([]byte(valBody), t)
+	val, err := UnmarshalOpt([]byte(valBody), t, opt)
 	if err != nil {
 		return cty.NilVal, path.NewError(err)
 	}
@@ -456,4 +458,28 @@ func bufDecoder(buf []byte) *json.Decoder {
 	dec := json.NewDecoder(r)
 	dec.UseNumber()
 	return dec
+}
+
+func unmarshalIntoDynamic(buf []byte, path cty.Path, opt *UnmarshalOptions) (cty.Value, error) {
+	var t cty.Type
+	var err error
+
+	if buf == nil {
+		return cty.NilVal, path.NewErrorf("missing value in dynamically-typed value")
+	}
+
+	t, err = ImpliedType(buf)
+	if err != nil {
+		return cty.NilVal, path.NewErrorf("failed to imply dynamic type: %s", err)
+	}
+
+	if t == cty.NilType {
+		return cty.NilVal, path.NewErrorf("missing type in dynamically-typed value")
+	}
+
+	val, err := unmarshal(buf, t, path, opt)
+	if err != nil {
+		return cty.NilVal, path.NewError(err)
+	}
+	return val, nil
 }

--- a/cty/json/value.go
+++ b/cty/json/value.go
@@ -61,5 +61,22 @@ func Marshal(val cty.Value, t cty.Type) ([]byte, error) {
 // may be a cty.PathError.
 func Unmarshal(buf []byte, t cty.Type) (cty.Value, error) {
 	var path cty.Path
-	return unmarshal(buf, t, path)
+	return unmarshal(buf, t, path, &UnmarshalOptions{})
+}
+
+// UnmarshalOpt decodes a JSON representation of the given value into a cty Value
+// conforming to the given type while following certain decoding options.
+//
+// While decoding, type conversions will be done where possible to make
+// the result conformant even if the types given in JSON are not exactly
+// correct. If conversion isn't possible then an error is returned, which
+// may be a cty.PathError.
+func UnmarshalOpt(buf []byte, t cty.Type, opt *UnmarshalOptions) (cty.Value, error) {
+	var path cty.Path
+	return unmarshal(buf, t, path, opt)
+}
+
+// UnmarshalOptions configures options for the JSON to CTY decoder.
+type UnmarshalOptions struct {
+	ImpliedDynamic bool
 }

--- a/cty/json/value.go
+++ b/cty/json/value.go
@@ -61,22 +61,21 @@ func Marshal(val cty.Value, t cty.Type) ([]byte, error) {
 // may be a cty.PathError.
 func Unmarshal(buf []byte, t cty.Type) (cty.Value, error) {
 	var path cty.Path
-	return unmarshal(buf, t, path, &UnmarshalOptions{})
+	return unmarshal(buf, t, path, &unmarshalOptions{})
 }
 
-// UnmarshalOpt decodes a JSON representation of the given value into a cty Value
-// conforming to the given type while following certain decoding options.
+// UnmarshalDynamicWithImpliedType decodes a JSON representation of the
+// given value into a cty.Value conforming to the given type while replacing
+// dynamicPseudoType attributes with their implied type.
+//
+// Implied types are a best-effort deduction of the type from the structure
+// of the input JSON.
 //
 // While decoding, type conversions will be done where possible to make
 // the result conformant even if the types given in JSON are not exactly
 // correct. If conversion isn't possible then an error is returned, which
 // may be a cty.PathError.
-func UnmarshalOpt(buf []byte, t cty.Type, opt *UnmarshalOptions) (cty.Value, error) {
+func UnmarshalDynamicWithImpliedType(buf []byte, t cty.Type) (cty.Value, error) {
 	var path cty.Path
-	return unmarshal(buf, t, path, opt)
-}
-
-// UnmarshalOptions configures options for the JSON to CTY decoder.
-type UnmarshalOptions struct {
-	ImpliedDynamic bool
+	return unmarshal(buf, t, path, &unmarshalOptions{ImpliedDynamic: true})
 }

--- a/cty/json/value_test.go
+++ b/cty/json/value_test.go
@@ -271,3 +271,46 @@ func TestValueJSONable(t *testing.T) {
 		})
 	}
 }
+
+func TestJSONIntoDynamic(t *testing.T) {
+	var container cty.Type = cty.Object(map[string]cty.Type{
+		"payload": cty.DynamicPseudoType,
+	})
+
+	tests := []struct {
+		Value  cty.Value
+		Type   cty.Type
+		From   string
+		DecVal cty.Value
+	}{
+		{
+			cty.ObjectVal(map[string]cty.Value{"foo": cty.True, "bar": cty.StringVal("test")}),
+			cty.Object(map[string]cty.Type{"foo": cty.Bool, "bar": cty.String}),
+			`{"payload":{"foo":true,"bar":"test"}}`,
+			cty.ObjectVal(map[string]cty.Value{"payload": cty.ObjectVal(map[string]cty.Value{"foo": cty.True, "bar": cty.StringVal("test")})}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%#v to %#v", test.Value, test.Type), func(t *testing.T) {
+
+			newVal, err := UnmarshalOpt([]byte(test.From), container, &UnmarshalOptions{ImpliedDynamic: true})
+			if err != nil {
+				t.Fatalf("unexpected error from Unmarshal: %s", err)
+			}
+
+			if !newVal.Type().Equals(test.DecVal.Type()) {
+				t.Errorf(
+					"mismatch after Unmarshal\njson: %s\ntype: %#v\ngot:  %#v\nwant: %#v",
+					test.From, test.Type, newVal, test.Value,
+				)
+			}
+			if !newVal.RawEquals(test.DecVal) {
+				t.Errorf(
+					"mismatch after Unmarshal\njson: %s\ntype: %#v\ngot:  %#v\nwant: %#v",
+					test.From, test.Type, newVal, test.Value,
+				)
+			}
+		})
+	}
+}

--- a/cty/json/value_test.go
+++ b/cty/json/value_test.go
@@ -294,7 +294,7 @@ func TestJSONIntoDynamic(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%#v to %#v", test.Value, test.Type), func(t *testing.T) {
 
-			newVal, err := UnmarshalOpt([]byte(test.From), container, &UnmarshalOptions{ImpliedDynamic: true})
+			newVal, err := UnmarshalDynamicWithImpliedType([]byte(test.From), container)
 			if err != nil {
 				t.Fatalf("unexpected error from Unmarshal: %s", err)
 			}


### PR DESCRIPTION
This change modifies the JSON unmarhsaler to allow the caller to specify whether they want dynamicPseudoType attributes to source their type information from the serialized type carried in the wire format or to deduce (imply) the type from the structure of the value.

This change is necessary in order to support unmarshaling JSON produced from systems that are not aware of CTY into attributes that are specified as dynamicPseudoType.

The concrete use-case that led to requiring this change is circumventing recursive type structures encountered in the Kubernetes API by the new Kubernetes provider. In such cases, a type containing an attribute of the same type as the parent cannot currently be expressed in CTY explicitly. A workaround is to express the top-most type in the loop as dynamic.