### PR TITLE
Forward to v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.4.2 (Unreleased)
 
+* `function/stdlib`: The `jsonencode` function will now correctly accept a null as its argument, and produce the JSON representation `"null"` rather than returning an error. ([#54](https://github.com/zclconf/go-cty/pull/54))
 * `convert`: Don't panic when asked to convert a tuple of objects to a list type constraint containing a nested `cty.DynamicPseudoType`. ([#53](https://github.com/zclconf/go-cty/pull/53))
 
 # 1.4.1 (March 5, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.4.2 (May 29, 2020)
+# 1.4.2 (Unreleased)
 
 * `function/stdlib`: The `jsonencode` function will now correctly accept a null as its argument, and produce the JSON representation `"null"` rather than returning an error. ([#54](https://github.com/zclconf/go-cty/pull/54))
 * `convert`: Don't panic when asked to convert a tuple of objects to a list type constraint containing a nested `cty.DynamicPseudoType`. ([#53](https://github.com/zclconf/go-cty/pull/53))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.4.2 (Unreleased)
+# 1.4.2 (May 29, 2020)
 
 * `function/stdlib`: The `jsonencode` function will now correctly accept a null as its argument, and produce the JSON representation `"null"` rather than returning an error. ([#54](https://github.com/zclconf/go-cty/pull/54))
 * `convert`: Don't panic when asked to convert a tuple of objects to a list type constraint containing a nested `cty.DynamicPseudoType`. ([#53](https://github.com/zclconf/go-cty/pull/53))

--- a/cty/function/stdlib/json.go
+++ b/cty/function/stdlib/json.go
@@ -12,6 +12,7 @@ var JSONEncodeFunc = function.New(&function.Spec{
 			Name:             "val",
 			Type:             cty.DynamicPseudoType,
 			AllowDynamicType: true,
+			AllowNull:        true,
 		},
 	},
 	Type: function.StaticReturnType(cty.String),
@@ -22,6 +23,10 @@ var JSONEncodeFunc = function.New(&function.Spec{
 			// contains any _nested_ unknowns then our result must be
 			// unknown.
 			return cty.UnknownVal(retType), nil
+		}
+
+		if val.IsNull() {
+			return cty.StringVal("null"), nil
 		}
 
 		buf, err := json.Marshal(val, val.Type())

--- a/cty/function/stdlib/json_test.go
+++ b/cty/function/stdlib/json_test.go
@@ -52,6 +52,10 @@ func TestJSONEncode(t *testing.T) {
 			cty.DynamicVal,
 			cty.UnknownVal(cty.String),
 		},
+		{
+			cty.NullVal(cty.String),
+			cty.StringVal("null"),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Follow-up to https://github.com/hashicorp/go-cty/pull/7 for parity with zclconf/go-cty v1.4.2.

On further thought, I'm liking "Unreleased" and no release tag for the moment. This prevents a flood of Dependabot PRs like https://github.com/hashicorp/terraform-plugin-testing/pull/444 for all affected providers.

Update method:
```
# Set up local Git repository

$ git clone git@github.com:hashicorp/go-cty.git hashicorp-go-cty
$ cd hashicorp-go-cty
$ git remote add upstream git@github.com:zclconf/go-cty.git --no-tags

$ git remote -v
origin	git@github.com:hashicorp/go-cty.git (fetch)
origin	git@github.com:hashicorp/go-cty.git (push)
upstream	git@github.com:zclconf/go-cty.git (fetch)
upstream	git@github.com:zclconf/go-cty.git (push)

# Find commit refs for the current version and the next version

$ git ls-remote upstream refs/tags/v1.4.1^{}
c1fac28a50c9c3cdbbad888b289e2928a790015b	refs/tags/v1.4.1^{}

$ git ls-remote upstream refs/tags/v1.4.2^{}
e4e179713c4787a2b3837353fde2c1fe38bebe22	refs/tags/v1.4.2^{}

# Apply the commits to a new branch

$ git log --oneline c1fac28a50c9c3cdbbad888b289e2928a790015b..e4e179713c4787a2b3837353fde2c1fe38bebe22
e4e1797 v1.4.2 release
dd574de Update CHANGELOG.md
e76fe06 function/stdlib: jsonencode should produce a string representation of null
6e20bc2 Prepare CHANGELOG for a forthcoming 1.4.2 release

$ git log --oneline --format=%h --reverse c1fac28a50c9c3cdbbad888b289e2928a790015b..e4e179713c4787a2b3837353fde2c1fe38bebe22
6e20bc2
e76fe06
dd574de
e4e1797

$ git checkout -b forward-to-1.4.2
$ git cherry-pick $(git log --oneline --format=%h --reverse c1fac28a50c9c3cdbbad888b289e2928a790015b..e4e179713c4787a2b3837353fde2c1fe38bebe22) # and resolve conflicts in CHANGELOG.md

$ # Update CHANGELOG.md

# Verify

## Check module name in Go files
$ ag zclconf -G '.go$'

## Inspect diff
$ git diff -U0 e4e179713c4787a2b3837353fde2c1fe38bebe22..HEAD

## Inspect simpler diff
git diff -U0 --ignore-matching-lines 'github.com/(hashicorp|zclconf)/go-cty' e4e179713c4787a2b3837353fde2c1fe38bebe22..HEAD -- . ':(exclude).github/CODEOWNERS'

diff --git a/CHANGELOG.md b/CHANGELOG.md
index 3767291..ac175df 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1 +1 @@
-# 1.4.2 (May 29, 2020)
+# 1.4.2 (Unreleased)
@@ -5 +6 @@
-# 1.4.1 (May 18, 2020)
+# 1.4.1 (March 5, 2025)
diff --git a/cty/function/stdlib/string.go b/cty/function/stdlib/string.go
index 01ebc47..60e0ab5 100644
--- a/cty/function/stdlib/string.go
+++ b/cty/function/stdlib/string.go
@@ -154 +153,0 @@ var SubstrFunc = function.New(&function.Spec{
-
```