### PR TITLE
Forward to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.5.0 (Unreleased)
+# 1.5.0 (June 11, 2020)
 
 * `cty`: New `Value.HasWhollyKnownType` method, for testing whether a value's type could potentially change if any unknown values it was constructed from were to become known. ([#55](https://github.com/zclconf/go-cty/pull/55))
 * `convert`: Fix incorrect panic when converting a tuple with a dynamic-typed null member into a list or set, due to overly-liberal type unification. ([#56](https://github.com/zclconf/go-cty/pull/56))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 1.4.2 (Unreleased)
+# 1.5.0 (Unreleased)
+
+
+# 1.4.2 (May 29, 2020)
 
 * `function/stdlib`: The `jsonencode` function will now correctly accept a null as its argument, and produce the JSON representation `"null"` rather than returning an error. ([#54](https://github.com/zclconf/go-cty/pull/54))
 * `convert`: Don't panic when asked to convert a tuple of objects to a list type constraint containing a nested `cty.DynamicPseudoType`. ([#53](https://github.com/zclconf/go-cty/pull/53))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.5.0 (Unreleased)
 
+* `cty`: New `Value.HasWhollyKnownType` method, for testing whether a value's type could potentially change if any unknown values it was constructed from were to become known. ([#55](https://github.com/zclconf/go-cty/pull/55))
 * `convert`: Fix incorrect panic when converting a tuple with a dynamic-typed null member into a list or set, due to overly-liberal type unification. ([#56](https://github.com/zclconf/go-cty/pull/56))
 
 # 1.4.2 (May 29, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-# 1.5.0 (June 11, 2020)
+# 1.5.0 (Unreleased)
 
 * `cty`: New `Value.HasWhollyKnownType` method, for testing whether a value's type could potentially change if any unknown values it was constructed from were to become known. ([#55](https://github.com/zclconf/go-cty/pull/55))
 * `convert`: Fix incorrect panic when converting a tuple with a dynamic-typed null member into a list or set, due to overly-liberal type unification. ([#56](https://github.com/zclconf/go-cty/pull/56))
 
-# 1.4.2 (May 29, 2020)
+# 1.4.2 (Unreleased)
 
 * `function/stdlib`: The `jsonencode` function will now correctly accept a null as its argument, and produce the JSON representation `"null"` rather than returning an error. ([#54](https://github.com/zclconf/go-cty/pull/54))
 * `convert`: Don't panic when asked to convert a tuple of objects to a list type constraint containing a nested `cty.DynamicPseudoType`. ([#53](https://github.com/zclconf/go-cty/pull/53))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.5.0 (Unreleased)
 
+* `convert`: Fix incorrect panic when converting a tuple with a dynamic-typed null member into a list or set, due to overly-liberal type unification. ([#56](https://github.com/zclconf/go-cty/pull/56))
 
 # 1.4.2 (May 29, 2020)
 

--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -677,6 +677,95 @@ func TestConvert(t *testing.T) {
 			}),
 			WantError: false,
 		},
+		// https://github.com/hashicorp/terraform/issues/24377:
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("a")}),
+				cty.StringVal("b"),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			Type:      cty.Set(cty.DynamicPseudoType),
+			WantError: true,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("a")}),
+				cty.StringVal("b"),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			Type:      cty.List(cty.DynamicPseudoType),
+			WantError: true,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("a")}),
+				cty.StringVal("b"),
+			}),
+			Type:      cty.Set(cty.DynamicPseudoType),
+			WantError: true,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("a")}),
+				cty.StringVal("b"),
+			}),
+			Type:      cty.List(cty.DynamicPseudoType),
+			WantError: true,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.NumberIntVal(9),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			Type: cty.Set(cty.DynamicPseudoType),
+			Want: cty.SetVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.StringVal("9"),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			WantError: false,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.NumberIntVal(9),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			Type: cty.List(cty.DynamicPseudoType),
+			Want: cty.ListVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.StringVal("9"),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			WantError: false,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			Type: cty.Set(cty.DynamicPseudoType),
+			Want: cty.SetVal([]cty.Value{
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			WantError: false,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			Type: cty.List(cty.DynamicPseudoType),
+			Want: cty.ListVal([]cty.Value{
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			WantError: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/cty/type.go
+++ b/cty/type.go
@@ -87,7 +87,7 @@ func (t Type) HasDynamicTypes() bool {
 	case t.IsPrimitiveType():
 		return false
 	case t.IsCollectionType():
-		return false
+		return t.ElementType().HasDynamicTypes()
 	case t.IsObjectType():
 		attrTypes := t.AttributeTypes()
 		for _, at := range attrTypes {

--- a/cty/type_test.go
+++ b/cty/type_test.go
@@ -1,0 +1,56 @@
+package cty
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestHasDynamicTypes(t *testing.T) {
+	tests := []struct {
+		ty       Type
+		expected bool
+	}{
+		{
+			DynamicPseudoType,
+			true,
+		},
+		{
+			List(DynamicPseudoType),
+			true,
+		},
+		{
+			Tuple([]Type{String, DynamicPseudoType}),
+			true,
+		},
+		{
+			Object(map[string]Type{
+				"a":       String,
+				"unknown": DynamicPseudoType,
+			}),
+			true,
+		},
+		{
+			List(Object(map[string]Type{
+				"a":       String,
+				"unknown": DynamicPseudoType,
+			})),
+			true,
+		},
+		{
+			Tuple([]Type{Object(map[string]Type{
+				"a":       String,
+				"unknown": DynamicPseudoType,
+			})}),
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%#v.HasDynamicTypes()", test.ty), func(t *testing.T) {
+			got := test.ty.HasDynamicTypes()
+			if got != test.expected {
+				t.Errorf("Equals returned %#v; want %#v", got, test.expected)
+			}
+		})
+	}
+}

--- a/cty/value.go
+++ b/cty/value.go
@@ -106,3 +106,37 @@ func (val Value) IsWhollyKnown() bool {
 		return true
 	}
 }
+
+// HasWhollyKnownType checks if the value is dynamic, or contains any nested
+// DynamicVal. This implies that both the value is not known, and the final
+// type may change.
+func (val Value) HasWhollyKnownType() bool {
+	// a null dynamic type is known
+	if val.IsNull() {
+		return true
+	}
+
+	// an unknown DynamicPseudoType is a DynamicVal, but we don't want to
+	// check that value for equality here, since this method is used within the
+	// equality check.
+	if !val.IsKnown() && val.ty == DynamicPseudoType {
+		return false
+	}
+
+	if val.CanIterateElements() {
+		// if the value is not known, then we can look directly at the internal
+		// types
+		if !val.IsKnown() {
+			return !val.ty.HasDynamicTypes()
+		}
+
+		for it := val.ElementIterator(); it.Next(); {
+			_, ev := it.Element()
+			if !ev.HasWhollyKnownType() {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/cty/value_ops.go
+++ b/cty/value_ops.go
@@ -133,9 +133,9 @@ func (val Value) Equals(other Value) Value {
 	case val.IsKnown() && !other.IsKnown():
 		switch {
 		case val.IsNull(), other.ty.HasDynamicTypes():
-			// If known is Null, we need to wait for the unkown value since
+			// If known is Null, we need to wait for the unknown value since
 			// nulls of any type are equal.
-			// An unkown with a dynamic type compares as unknown, which we need
+			// An unknown with a dynamic type compares as unknown, which we need
 			// to check before the type comparison below.
 			return UnknownVal(Bool)
 		case !val.ty.Equals(other.ty):
@@ -148,9 +148,9 @@ func (val Value) Equals(other Value) Value {
 	case other.IsKnown() && !val.IsKnown():
 		switch {
 		case other.IsNull(), val.ty.HasDynamicTypes():
-			// If known is Null, we need to wait for the unkown value since
+			// If known is Null, we need to wait for the unknown value since
 			// nulls of any type are equal.
-			// An unkown with a dynamic type compares as unknown, which we need
+			// An unknown with a dynamic type compares as unknown, which we need
 			// to check before the type comparison below.
 			return UnknownVal(Bool)
 		case !other.ty.Equals(val.ty):
@@ -171,7 +171,15 @@ func (val Value) Equals(other Value) Value {
 		return BoolVal(false)
 	}
 
-	if val.ty.HasDynamicTypes() || other.ty.HasDynamicTypes() {
+	// Check if there are any nested dynamic values making this comparison
+	// unknown.
+	if !val.HasWhollyKnownType() || !other.HasWhollyKnownType() {
+		// Even if we have dynamic values, we can still determine inequality if
+		// there is no way the types could later conform.
+		if val.ty.TestConformance(other.ty) != nil && other.ty.TestConformance(val.ty) != nil {
+			return BoolVal(false)
+		}
+
 		return UnknownVal(Bool)
 	}
 


### PR DESCRIPTION
Previously: #8

This PR updates this repo for parity with zclconf/go-cty v1.5.0. The changes remain "Unreleased" with no new release tag for the moment. This prevents a flood of Dependabot PRs like https://github.com/hashicorp/terraform-plugin-testing/pull/444 for all affected providers.

Verification:
```
$ git ls-remote upstream refs/tags/v1.5.0^{}
17dfd6f7bef43edcb91484e94cedd0eafb393266	refs/tags/v1.5.0^{}

# Check for non-trivial diffs between this v1.5.0 and upstream v1.5.0
$ git diff -U0 --ignore-matching-lines 'github.com/(hashicorp|zclconf)/go-cty' 17dfd6f7bef43edcb91484e94cedd0eafb393266..HEAD -- . ':(exclude).github/CODEOWNERS'
diff --git a/CHANGELOG.md b/CHANGELOG.md
index c0bf2c5..7cb85b0 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1 +1 @@
-# 1.5.0 (June 11, 2020)
+# 1.5.0 (Unreleased)
@@ -6 +6 @@
-# 1.4.2 (May 29, 2020)
+# 1.4.2 (Unreleased)
@@ -10 +11 @@
-# 1.4.1 (May 18, 2020)
+# 1.4.1 (March 5, 2025)
diff --git a/cty/function/stdlib/string.go b/cty/function/stdlib/string.go
index 01ebc47..60e0ab5 100644
--- a/cty/function/stdlib/string.go
+++ b/cty/function/stdlib/string.go
@@ -154 +153,0 @@ var SubstrFunc = function.New(&function.Spec{
-

$ go1.12 test ./...
ok  	github.com/hashicorp/go-cty/cty	(cached)
ok  	github.com/hashicorp/go-cty/cty/convert	(cached)
ok  	github.com/hashicorp/go-cty/cty/function	(cached)
ok  	github.com/hashicorp/go-cty/cty/function/stdlib	(cached)
ok  	github.com/hashicorp/go-cty/cty/gocty	(cached)
ok  	github.com/hashicorp/go-cty/cty/json	(cached)
ok  	github.com/hashicorp/go-cty/cty/msgpack	(cached)
ok  	github.com/hashicorp/go-cty/cty/set	(cached)

# Check for any un-replaced imports
$  ag zclconf -G '.go$'

```