### PR TITLE
Forward to 1.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.11.x
-  - 1.12.x
+  - 1.13.x
   - tip
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.6.1 (Unreleased)
+
 # 1.6.0 (Unreleased)
 
 * Fixed various defects in the handling of sets containing unknown values. This will cause unknown values to now be returned in more situations, whereas before `cty` would often return incorrect results when working with sets containing unknown values. The list of defects fixed in this release includes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.6.1 (Unreleased)
 
+* Fix a regression from 1.6.0 where `Value.RawEqual` no longer returned the correct result given a pair of sets containing partially-unknown values. ([#64](https://github.com/zclconf/go-cty/pull/64))
+
 # 1.6.0 (Unreleased)
 
 * Fixed various defects in the handling of sets containing unknown values. This will cause unknown values to now be returned in more situations, whereas before `cty` would often return incorrect results when working with sets containing unknown values. The list of defects fixed in this release includes:


### PR DESCRIPTION
Previously: #15

This PR updates this repo for parity with zclconf/go-cty v1.6.1. The changes remain "Unreleased" with no new release tag for the moment. In fact, this fixes a regression in (unreleased) v1.6.0 -- see CHANGELOG.md in the diff.

This prevents a flood of Dependabot PRs like https://github.com/hashicorp/terraform-plugin-testing/pull/444 for all affected providers.

Verification:
```
$ git ls-remote upstream refs/tags/v1.6.1^{}
7c4f1e0d1ca9f0324182c90ccc377d812374e916	refs/tags/v1.6.1^{}

$ # Check for non-trivial diffs between this v1.6.1 and upstream v1.6.1
$ GIT_PAGER= git diff -U0 --ignore-matching-lines 'github.com/(hashicorp|zclconf)/go-cty' 7c4f1e0..HEAD -- . ':(exclude).github/CODEOWNERS'

[CHANGELOG.md go.mod go.sum]

$ go1.12 test ./...
ok  	github.com/hashicorp/go-cty/cty	1.254s
ok  	github.com/hashicorp/go-cty/cty/convert	0.966s
ok  	github.com/hashicorp/go-cty/cty/function	0.740s
ok  	github.com/hashicorp/go-cty/cty/function/stdlib	1.035s
ok  	github.com/hashicorp/go-cty/cty/gocty	0.634s
ok  	github.com/hashicorp/go-cty/cty/json	0.887s
ok  	github.com/hashicorp/go-cty/cty/msgpack	1.124s
ok  	github.com/hashicorp/go-cty/cty/set	0.502s

# Check for any un-replaced imports
$  ag zclconf -G '.go$'
```